### PR TITLE
chore: add GitHub Actions workflow for running tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,56 @@
+name: Run Tests
+
+env:
+  PNPM_VERSION: "9.6.0"
+  NODE_VERSION: "20.19.4"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - name: Get pnpm store directory
+        shell: bash
+        run: |
+          echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Upload coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate running tests on the repository. The workflow ensures that tests are executed on every push and pull request to the `main` branch, sets up the necessary Node.js and pnpm environments, caches dependencies for faster runs, and uploads coverage reports after tests complete.

Continuous integration setup:

* Added `.github/workflows/test.yml` to define a CI workflow that runs tests on pushes and pull requests to `main` using GitHub Actions.
* Configured environment variables for `NODE_VERSION` and `PNPM_VERSION` to ensure consistent runtime environments.
* Set up dependency caching for pnpm to speed up repeated workflow executions.

Test execution and reporting:

* Automated installation of dependencies and running of tests using pnpm.
* Added a step to upload test coverage reports as workflow artifacts for further inspection.