### PR TITLE
Auth

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -17,20 +17,14 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
-  const showAnalytics =
-    process.env.NODE_ENV === "production" &&
-    Boolean(process.env.NEXT_PUBLIC_VERCEL_ANALYTICS_ID?.trim());
-
   return (
     <html lang="en">
       <body className={cn("bg-background", inter.className)}>
         {children}
-        {showAnalytics ? (
-          <>
-            <Analytics />
-            <SpeedInsights />
-          </>
-        ) : null}
+        <>
+          <Analytics />
+          <SpeedInsights />
+        </>
       </body>
     </html>
   );


### PR DESCRIPTION
This pull request simplifies the logic for rendering the analytics components in the `RootLayout` by always including them, regardless of environment variables or production status.

Rendering logic update:

* The conditional check for `showAnalytics` based on `NODE_ENV` and `NEXT_PUBLIC_VERCEL_ANALYTICS_ID` was removed, so `Analytics` and `SpeedInsights` are now always rendered in `app/layout.tsx`.