### PR TITLE
fix: use site URL for redirects to address Cloud Run localhost issue

### DIFF
--- a/app/(auth)/auth/confirm/route.ts
+++ b/app/(auth)/auth/confirm/route.ts
@@ -3,6 +3,8 @@ import { type NextRequest, NextResponse } from "next/server";
 import { createClient } from "@/src/infrastructure/supabase/server";
 import { HandleOAuthCallbackUseCase } from "@/src/application/use-cases/auth/HandleOAuthCallbackUseCase";
 import { SupabaseAuthRepository } from "@/src/infrastructure/repositories/SupabaseAuthRepository";
+import { buildRedirectUrl } from "@/src/lib/url-helpers";
+
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const { searchParams } = new URL(request.url);
@@ -10,13 +12,6 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
   const type = searchParams.get("type") as EmailOtpType | null;
   const next = searchParams.get("next") ?? "/";
   const code = searchParams.get("code");
-
-  const redirectTo = request.nextUrl.clone();
-  redirectTo.pathname = next;
-  redirectTo.searchParams.delete("token_hash");
-  redirectTo.searchParams.delete("type");
-  redirectTo.searchParams.delete("next");
-  redirectTo.searchParams.delete("code");
 
   const supabase = createClient();
 
@@ -34,12 +29,13 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       });
 
       if (result.success) {
-        redirectTo.pathname = result.redirectTo || "/dashboard";
-        return NextResponse.redirect(redirectTo);
+        const dashboardUrl = buildRedirectUrl(result.redirectTo || "/dashboard");
+        return NextResponse.redirect(dashboardUrl);
       } else {
-        redirectTo.pathname = "/error";
-        redirectTo.searchParams.set("error", "auth_failed");
-        return NextResponse.redirect(redirectTo);
+        const params = new URLSearchParams();
+        params.set("error", "auth_failed");
+        const errorUrl = buildRedirectUrl("/error", params);
+        return NextResponse.redirect(errorUrl);
       }
     }
 
@@ -53,16 +49,18 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       if (!error) {
         // If it's recovery, ALWAYS redirect to update password
         if (type === "recovery") {
-          redirectTo.pathname = "/auth/update-password";
-          return NextResponse.redirect(redirectTo);
+          const recoveryUrl = buildRedirectUrl("/auth/update-password");
+          return NextResponse.redirect(recoveryUrl);
         }
 
         // For other types (signup, etc), use the next or home
-        return NextResponse.redirect(redirectTo);
+        const successUrl = buildRedirectUrl(next);
+        return NextResponse.redirect(successUrl);
       } else {
-        redirectTo.pathname = "/error";
-        redirectTo.searchParams.set("error", "otp_verification_failed");
-        return NextResponse.redirect(redirectTo);
+        const params = new URLSearchParams();
+        params.set("error", "otp_verification_failed");
+        const errorUrl = buildRedirectUrl("/error", params);
+        return NextResponse.redirect(errorUrl);
       }
     }
 
@@ -71,16 +69,20 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       data: { user },
     } = await supabase.auth.getUser();
     if (user) {
-      return NextResponse.redirect(redirectTo);
+      const userUrl = buildRedirectUrl(next);
+      return NextResponse.redirect(userUrl);
     }
 
     // If we reach here without valid parameters, redirect to error
-    redirectTo.pathname = "/error";
-    redirectTo.searchParams.set("error", "invalid_auth_params");
-    return NextResponse.redirect(redirectTo);
+    const params = new URLSearchParams();
+    params.set("error", "invalid_auth_params");
+    const errorUrl = buildRedirectUrl("/error", params);
+    return NextResponse.redirect(errorUrl);
   } catch (error) {
-    redirectTo.pathname = "/error";
-    redirectTo.searchParams.set("error", "unexpected_error");
-    return NextResponse.redirect(redirectTo);
+    const params = new URLSearchParams();
+    params.set("error", "unexpected_error");
+    const errorUrl = buildRedirectUrl("/error", params);
+    return NextResponse.redirect(errorUrl);
   }
 }
+

--- a/app/(auth)/auth/confirm/route.ts
+++ b/app/(auth)/auth/confirm/route.ts
@@ -5,7 +5,6 @@ import { HandleOAuthCallbackUseCase } from "@/src/application/use-cases/auth/Han
 import { SupabaseAuthRepository } from "@/src/infrastructure/repositories/SupabaseAuthRepository";
 import { buildRedirectUrl } from "@/src/lib/url-helpers";
 
-
 export async function GET(request: NextRequest): Promise<NextResponse> {
   const { searchParams } = new URL(request.url);
   const tokenHash = searchParams.get("token_hash");
@@ -29,7 +28,9 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
       });
 
       if (result.success) {
-        const dashboardUrl = buildRedirectUrl(result.redirectTo || "/dashboard");
+        const dashboardUrl = buildRedirectUrl(
+          result.redirectTo || "/dashboard"
+        );
         return NextResponse.redirect(dashboardUrl);
       } else {
         const params = new URLSearchParams();
@@ -85,4 +86,3 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
     return NextResponse.redirect(errorUrl);
   }
 }
-

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,5 +1,7 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { updateSession } from "@/src/infrastructure/supabase/middleware";
+import { buildRedirectUrl } from "@/src/lib/url-helpers";
+
 
 export async function middleware(request: NextRequest): Promise<NextResponse> {
   const { pathname } = request.nextUrl;
@@ -38,16 +40,15 @@ export async function middleware(request: NextRequest): Promise<NextResponse> {
 
   // If user is authenticated and tries to access auth routes, redirect to dashboard
   if (user && (pathname === "/login" || pathname === "/signup")) {
-    const url = request.nextUrl.clone();
-    url.pathname = "/dashboard";
+    const url = buildRedirectUrl("/dashboard");
     return NextResponse.redirect(url);
   }
 
   // If user is NOT authenticated and tries to access a protected route
   if (!user && isProtectedRoute) {
-    const url = request.nextUrl.clone();
-    url.pathname = "/login";
-    url.searchParams.set("redirect", pathname);
+    const params = new URLSearchParams();
+    params.set("redirect", pathname);
+    const url = buildRedirectUrl("/login", params);
     return NextResponse.redirect(url);
   }
 

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,6 @@ import { type NextRequest, NextResponse } from "next/server";
 import { updateSession } from "@/src/infrastructure/supabase/middleware";
 import { buildRedirectUrl } from "@/src/lib/url-helpers";
 
-
 export async function middleware(request: NextRequest): Promise<NextResponse> {
   const { pathname } = request.nextUrl;
 

--- a/src/lib/url-helpers.ts
+++ b/src/lib/url-helpers.ts
@@ -1,7 +1,7 @@
 /**
  * Builds a redirect URL using the configured site URL from environment variables.
  * This is needed for Cloud Run where request.nextUrl.clone() returns localhost.
- * 
+ *
  * @param pathname - The path to redirect to (e.g., "/dashboard", "/auth/update-password")
  * @param searchParams - Optional URL search parameters to include in the redirect
  * @returns A fully qualified URL using the NEXT_PUBLIC_SITE_URL
@@ -10,8 +10,7 @@ export function buildRedirectUrl(
   pathname: string,
   searchParams?: URLSearchParams
 ): URL {
-  const siteUrl =
-    process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
   const url = new URL(pathname, siteUrl);
 
   if (searchParams) {

--- a/src/lib/url-helpers.ts
+++ b/src/lib/url-helpers.ts
@@ -1,0 +1,24 @@
+/**
+ * Builds a redirect URL using the configured site URL from environment variables.
+ * This is needed for Cloud Run where request.nextUrl.clone() returns localhost.
+ * 
+ * @param pathname - The path to redirect to (e.g., "/dashboard", "/auth/update-password")
+ * @param searchParams - Optional URL search parameters to include in the redirect
+ * @returns A fully qualified URL using the NEXT_PUBLIC_SITE_URL
+ */
+export function buildRedirectUrl(
+  pathname: string,
+  searchParams?: URLSearchParams
+): URL {
+  const siteUrl =
+    process.env.NEXT_PUBLIC_SITE_URL || "http://localhost:3000";
+  const url = new URL(pathname, siteUrl);
+
+  if (searchParams) {
+    searchParams.forEach((value, key) => {
+      url.searchParams.set(key, value);
+    });
+  }
+
+  return url;
+}


### PR DESCRIPTION
This pull request refactors how redirect URLs are constructed throughout the authentication and middleware logic to ensure URLs are correctly built using the configured site URL, addressing issues with incorrect hostnames in Cloud Run environments. The key change is the introduction and use of a new helper function, `buildRedirectUrl`, which replaces manual URL manipulation.

**Redirect URL construction improvements:**

* Added the new `buildRedirectUrl` helper in `src/lib/url-helpers.ts` to generate fully qualified URLs using the `NEXT_PUBLIC_SITE_URL` environment variable, ensuring correct redirects in all environments.
* Refactored all redirects in `app/(auth)/auth/confirm/route.ts` to use `buildRedirectUrl`, replacing previous manual mutation of `request.nextUrl` and improving error handling by consistently passing URL search parameters. [[1]](diffhunk://#diff-51581a7de07197e192e44f7f91ee83349ba1473fd27a9e5e6ec4c8a39fec17d3R6-R7) [[2]](diffhunk://#diff-51581a7de07197e192e44f7f91ee83349ba1473fd27a9e5e6ec4c8a39fec17d3L14-L20) [[3]](diffhunk://#diff-51581a7de07197e192e44f7f91ee83349ba1473fd27a9e5e6ec4c8a39fec17d3L37-R38) [[4]](diffhunk://#diff-51581a7de07197e192e44f7f91ee83349ba1473fd27a9e5e6ec4c8a39fec17d3L56-R63) [[5]](diffhunk://#diff-51581a7de07197e192e44f7f91ee83349ba1473fd27a9e5e6ec4c8a39fec17d3L74-R88)
* Updated `middleware.ts` to use `buildRedirectUrl` for all redirect cases, ensuring correct hostnames and query parameters when redirecting users based on authentication status. [[1]](diffhunk://#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1cR3-R4) [[2]](diffhunk://#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1cL41-R51)